### PR TITLE
Поддержка часовых поясов в ICS #53

### DIFF
--- a/create_web.py
+++ b/create_web.py
@@ -59,14 +59,15 @@ def shorten_url(url: str) -> str:
 # Функция возвращает таймзону для события на основе города
 def get_timezone_for_event(event: dict):
     """Возвращает таймзону для события на основе города."""
+    tz_moscow = "Europe/Moscow"
     timezones = {
-        "online": "Europe/Moscow",
-        "онлайн": "Europe/Moscow",
-        "санкт-петербург": "Europe/Moscow",
-        "москва": "Europe/Moscow",
+        "online": tz_moscow,
+        "онлайн": tz_moscow,
+        "санкт-петербург": tz_moscow,
+        "москва": tz_moscow,
         "новосибирск": "Asia/Novosibirsk",
         "иркутск": "Asia/Irkutsk",
-    }
+    }   
 
     city = str(event.get('city', '')).strip().lower()
     return timezones.get(city)


### PR DESCRIPTION
Добавил таймзону для календарей в зависимости от города.
Для онлайн - Московское время

Для остальных по городу. Но по четкому списку, его видимо придется вести дополнительно как-то. Ну или там оставить старую логику, что все добавляют свое время в своем часовом поясе