### PR TITLE
Service Worker: network-first для навигации, версия кеша по содержимому статики

### DIFF
--- a/create_web.py
+++ b/create_web.py
@@ -3,7 +3,9 @@
 Собирает YAML файлы событий и вебинаров, генерирует HTML, календари, RSS и JSON.
 """
 
+import hashlib
 import json
+import os
 import re
 import shutil
 from datetime import date, datetime, timedelta
@@ -36,6 +38,7 @@ TEMPLATE_FILE = Path('web/index.html')  # HTML шаблон сайта
 VIDEO_TEMPLATE_FILE = Path('web/video.html')  # HTML шаблон страницы видеозаписей
 ONEYEAR_TEMPLATE_FILE = Path('web/oneyear.html')  # HTML шаблон страницы итогов года
 SW_TEMPLATE_FILE = Path('web/sw.js')  # Шаблон Service Worker
+STATIC_CACHE_DIRS = ('icons', 'img')  # Статика, которую Service Worker кеширует надолго
 OUTPUT_DIR = Path('site')  # Папка для собранного сайта
 OUTPUT_FILE = OUTPUT_DIR / 'index.html'  # Итоговый HTML файл
 VIDEO_OUTPUT_FILE = OUTPUT_DIR / 'video' / 'index.html'  # HTML файл страницы видеозаписей
@@ -423,6 +426,25 @@ def build_year_stats(all_events: list[dict], all_webinars: list[dict]) -> dict[s
     }
 
 
+def build_static_version() -> str:
+    """Версия кеша Service Worker — хеш содержимого статики.
+
+    Считаем именно по файлам, а не по дате сборки: сайт пересобирается ежедневно,
+    но иконки и картинки меняются редко, и незачем сбрасывать кеш у пользователей,
+    когда сбрасывать нечего. Страницы от версии не зависят — они идут network-first.
+    """
+    paths = []
+    for directory in STATIC_CACHE_DIRS:
+        for root, _, files in os.walk(directory):
+            paths.extend(Path(root) / name for name in files if not name.startswith('.'))
+
+    digest = hashlib.sha256()
+    for path in sorted(paths):
+        digest.update(path.as_posix().encode('utf-8'))
+        digest.update(path.read_bytes())
+    return digest.hexdigest()[:12]
+
+
 def generate_sitemap() -> str:
     today_iso = date.today().isoformat()
     return f"""<?xml version="1.0" encoding="UTF-8"?>
@@ -512,9 +534,7 @@ def main() -> None:
     # Копируем статические файлы (картинки и иконки)
     shutil.copytree('img', 'site/img', dirs_exist_ok=True)
     shutil.copytree('icons', 'site/icons', dirs_exist_ok=True)
-    # Версия кеша Service Worker — дата сборки: сайт пересобирается ежедневно,
-    # так меняется сам sw.js и старые кеши сбрасываются в activate
-    sw_js = SW_TEMPLATE_FILE.read_text(encoding='utf-8').replace('{{ cache_version }}', date.today().isoformat())
+    sw_js = SW_TEMPLATE_FILE.read_text(encoding='utf-8').replace('{{ cache_version }}', build_static_version())
     (OUTPUT_DIR / 'sw.js').write_text(sw_js, encoding='utf-8')
 
     # Генерируем ICS календари

--- a/create_web.py
+++ b/create_web.py
@@ -35,6 +35,7 @@ WEBINARS_DIR = Path('webinars')  # Папка с YAML файлами вебин�
 TEMPLATE_FILE = Path('web/index.html')  # HTML шаблон сайта
 VIDEO_TEMPLATE_FILE = Path('web/video.html')  # HTML шаблон страницы видеозаписей
 ONEYEAR_TEMPLATE_FILE = Path('web/oneyear.html')  # HTML шаблон страницы итогов года
+SW_TEMPLATE_FILE = Path('web/sw.js')  # Шаблон Service Worker
 OUTPUT_DIR = Path('site')  # Папка для собранного сайта
 OUTPUT_FILE = OUTPUT_DIR / 'index.html'  # Итоговый HTML файл
 VIDEO_OUTPUT_FILE = OUTPUT_DIR / 'video' / 'index.html'  # HTML файл страницы видеозаписей
@@ -511,7 +512,10 @@ def main() -> None:
     # Копируем статические файлы (картинки и иконки)
     shutil.copytree('img', 'site/img', dirs_exist_ok=True)
     shutil.copytree('icons', 'site/icons', dirs_exist_ok=True)
-    shutil.copy('web/sw.js', OUTPUT_DIR / 'sw.js')
+    # Версия кеша Service Worker — дата сборки: сайт пересобирается ежедневно,
+    # так меняется сам sw.js и старые кеши сбрасываются в activate
+    sw_js = SW_TEMPLATE_FILE.read_text(encoding='utf-8').replace('{{ cache_version }}', date.today().isoformat())
+    (OUTPUT_DIR / 'sw.js').write_text(sw_js, encoding='utf-8')
 
     # Генерируем ICS календари
     calendar_dir = OUTPUT_DIR / 'calendar'

--- a/tests/test_create_web.py
+++ b/tests/test_create_web.py
@@ -24,6 +24,24 @@ def test_service_worker_template_is_versioned():
     assert '{{ cache_version }}' in template
 
 
+def test_build_static_version_tracks_content(tmp_path, monkeypatch):
+    assets = tmp_path / 'assets'
+    (assets / 'nested').mkdir(parents=True)
+    (assets / 'nested' / 'logo.png').write_bytes(b'one')
+    monkeypatch.setattr(create_web, 'STATIC_CACHE_DIRS', (str(assets),))
+
+    first = create_web.build_static_version()
+    assert create_web.build_static_version() == first
+
+    (assets / 'nested' / 'logo.png').write_bytes(b'two')
+    second = create_web.build_static_version()
+    assert second != first
+
+    # Мусор вроде .DS_Store не должен менять версию кеша
+    (assets / '.DS_Store').write_bytes(b'junk')
+    assert create_web.build_static_version() == second
+
+
 class TestCreateWeb:
     @patch('create_web.render_webinars_calendar')
     @patch('create_web.render_public_calendars')
@@ -117,7 +135,8 @@ class TestCreateWeb:
         mock_copytree.assert_any_call('icons', 'site/icons', dirs_exist_ok=True)
         sw_js = mock_write_text.call_args_list[0][0][0]
         assert '{{ cache_version }}' not in sw_js
-        assert date.today().isoformat() in sw_js
+        assert create_web.build_static_version() in sw_js
+        assert date.today().isoformat() not in sw_js
 
         assert mock_generate_event_calendars.call_count == 2
 

--- a/tests/test_create_web.py
+++ b/tests/test_create_web.py
@@ -18,6 +18,12 @@ def test_generate_sitemap():
     assert '<changefreq>daily</changefreq>' in result
 
 
+def test_service_worker_template_is_versioned():
+    template = create_web.SW_TEMPLATE_FILE.read_text(encoding='utf-8')
+
+    assert '{{ cache_version }}' in template
+
+
 class TestCreateWeb:
     @patch('create_web.render_webinars_calendar')
     @patch('create_web.render_public_calendars')
@@ -31,7 +37,6 @@ class TestCreateWeb:
     @patch('create_web.generate_webinars_public_calendar')
     @patch('create_web.generate_public_calendars')
     @patch('create_web.generate_event_calendars')
-    @patch('create_web.shutil.copy')
     @patch('create_web.shutil.copytree')
     @patch('create_web.format_date')
     @patch('create_web.yaml.safe_load')
@@ -50,7 +55,6 @@ class TestCreateWeb:
         mock_yaml_load,
         mock_format_date,
         mock_copytree,
-        mock_copy,
         mock_generate_event_calendars,
         mock_generate_public_calendars,
         mock_generate_webinars_public_calendar,
@@ -90,7 +94,8 @@ class TestCreateWeb:
         ]
 
         mock_read_text.return_value = (
-            '{{ events }}\n{{ webinars }}\n{{ public_calendars }}\n{{ webinars_calendar }}\n{{ builddate }}'
+            '{{ events }}\n{{ webinars }}\n{{ public_calendars }}\n{{ webinars_calendar }}\n'
+            '{{ builddate }}\n{{ cache_version }}'
         )
 
         mock_render_event.return_value = '<div>EVENT</div>'
@@ -110,7 +115,9 @@ class TestCreateWeb:
 
         mock_copytree.assert_any_call('img', 'site/img', dirs_exist_ok=True)
         mock_copytree.assert_any_call('icons', 'site/icons', dirs_exist_ok=True)
-        mock_copy.assert_any_call('web/sw.js', create_web.OUTPUT_DIR / 'sw.js')
+        sw_js = mock_write_text.call_args_list[0][0][0]
+        assert '{{ cache_version }}' not in sw_js
+        assert date.today().isoformat() in sw_js
 
         assert mock_generate_event_calendars.call_count == 2
 
@@ -161,7 +168,6 @@ class TestCreateWeb:
 
         with (
             patch('create_web.shutil.copytree'),
-            patch('create_web.shutil.copy'),
             patch('create_web.generate_event_calendars'),
             patch('create_web.generate_public_calendars'),
             patch('create_web.generate_webinars_public_calendar'),
@@ -206,7 +212,6 @@ class TestCreateWeb:
 
         with (
             patch('create_web.shutil.copytree'),
-            patch('create_web.shutil.copy'),
             patch('create_web.generate_event_calendars'),
             patch('create_web.generate_public_calendars'),
             patch('create_web.generate_webinars_public_calendar'),

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,6 +1,11 @@
+// Версия — хеш содержимого icons/ и img/: эта статика отдаётся из кеша,
+// поэтому её и нужно инвалидировать при изменении.
 const CACHE_VERSION = '{{ cache_version }}';
 const STATIC_CACHE = 'onevents-static-' + CACHE_VERSION;
-const PAGE_CACHE = 'onevents-page-' + CACHE_VERSION;
+
+// Кеш страниц не версионируем: страницы идут network-first, и здесь лежит
+// только офлайн-копия, которую каждый успешный ответ сети перезаписывает.
+const PAGE_CACHE = 'onevents-page';
 
 // Сколько ждём сеть на навигации, прежде чем отдать закешированную страницу
 const NETWORK_TIMEOUT_MS = 3000;

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,6 +1,9 @@
-const CACHE_VERSION = 'v1';
+const CACHE_VERSION = '{{ cache_version }}';
 const STATIC_CACHE = 'onevents-static-' + CACHE_VERSION;
 const PAGE_CACHE = 'onevents-page-' + CACHE_VERSION;
+
+// Сколько ждём сеть на навигации, прежде чем отдать закешированную страницу
+const NETWORK_TIMEOUT_MS = 3000;
 
 var STATIC_ASSETS = [
   '/',
@@ -39,6 +42,43 @@ self.addEventListener('activate', function (event) {
   self.clients.claim();
 });
 
+// Навигация: сначала сеть, чтобы страница всегда была свежей.
+// Кеш подставляем, только если сеть недоступна или не ответила за NETWORK_TIMEOUT_MS.
+function navigateNetworkFirst(request) {
+  return caches.open(PAGE_CACHE).then(function (cache) {
+    return new Promise(function (resolve) {
+      var settled = false;
+
+      function settle(response) {
+        if (settled || !response) {
+          return;
+        }
+        settled = true;
+        resolve(response);
+      }
+
+      var timer = setTimeout(function () {
+        cache.match(request).then(settle);
+      }, NETWORK_TIMEOUT_MS);
+
+      fetch(request)
+        .then(function (response) {
+          clearTimeout(timer);
+          if (response.ok) {
+            cache.put(request, response.clone());
+          }
+          settle(response);
+        })
+        .catch(function () {
+          clearTimeout(timer);
+          cache.match(request).then(function (cached) {
+            settle(cached || Response.error());
+          });
+        });
+    });
+  });
+}
+
 self.addEventListener('fetch', function (event) {
   var url = new URL(event.request.url);
 
@@ -51,19 +91,7 @@ self.addEventListener('fetch', function (event) {
   }
 
   if (event.request.mode === 'navigate') {
-    event.respondWith(
-      caches.open(PAGE_CACHE).then(function (cache) {
-        return cache.match(event.request).then(function (cached) {
-          var fetched = fetch(event.request).then(function (response) {
-            if (response.ok) {
-              cache.put(event.request, response.clone());
-            }
-            return response;
-          });
-          return cached || fetched;
-        });
-      })
-    );
+    event.respondWith(navigateNetworkFirst(event.request));
     return;
   }
 


### PR DESCRIPTION
## Проблема

**Навигация шла по stale-while-revalidate** (`web/sw.js`):

```js
var fetched = fetch(event.request).then(...cache.put...);
return cached || fetched;   // кеш выигрывает всегда, если он есть
```

Страница отдавалась из кеша мгновенно, свежая качалась в фон и попадала в кеш — то есть показывалась только **на следующем заходе**. Добавили событие — пользователь видел старый сайт, а новый получал лишь при повторном визите.

**Усугубляло:** `CACHE_VERSION = 'v1'` был захардкожен, а `create_web.py` копировал `sw.js` как есть. Файл при пересборке не менялся байт-в-байт → браузер не считал воркер обновлённым → `install`/`activate` не перезапускались, старые кеши статики не чистились никогда. Замена картинки с тем же именем до пользователя не доходила вообще.

## Что сделано

**1. Навигация — network-first с таймаутом 3с.** Кеш подставляется, только если сеть не ответила за таймаут или недоступна. Это и решает свежесть событий: `PAGE_CACHE` перестал быть источником страницы и стал офлайн-фолбэком.

**2. Версия кеша — хеш содержимого, а не дата сборки.** `build_static_version()` считает sha256 по файлам `icons/` и `img/` — по тому, что воркер реально отдаёт из кеша. Сайт пересобирается ежедневно, но это не значит, что он изменился; дата сборки сбрасывала бы кеш у всех пользователей каждый день на пустом месте. Скрытые файлы (`.DS_Store`) пропускаются, чтобы локальная сборка совпадала с CI.

**3. Кеш страниц развязан с версией.** `PAGE_CACHE` больше не версионируется: страницы идут network-first, его содержимое перезаписывает каждый успешный ответ сети. Смена иконки больше не стирает офлайн-копии страниц.

> Контент страниц намеренно **не** входит в `CACHE_VERSION`: свежесть страниц обеспечивает network-first, а не версия. Завести туда события — значит сбрасывать кеш иконок при каждой новой записи, ровно тот бесполезный сброс, от которого уходим.

## Разбор веток `navigateNetworkFirst`

| Ситуация | Поведение |
|---|---|
| Сеть отвечает быстро | Свежий ответ + запись в кеш |
| Таймаут, кеш есть | Отдаём кеш; фоновый `fetch` не отменяется и дописывает свежее в кеш |
| Таймаут, кеша нет | Продолжаем ждать сеть |
| Офлайн, кеш есть | Отдаём кеш |
| Офлайн, кеша нет | `Response.error()` — штатная ошибка сети |

## Проверка

- `pytest` — 135 passed; `ruff check .` — All checks passed
- `node --check site/sw.js` — синтаксис ок
- Поведение версии на реальных сборках:

| Прогон | Версия |
|---|---|
| Первая сборка | `c6b9166feaf2` |
| Повторная, ничего не менялось | `c6b9166feaf2` — не сменилась |
| Подменён `icons/favicon.ico` | `686b54b76916` — сменилась |
| Иконка возвращена | `c6b9166feaf2` — вернулась |

Новые тесты: `test_service_worker_template_is_versioned` (плейсхолдер на месте) и `test_build_static_version_tracks_content` (детерминированность, реакция на изменение файла, игнор `.DS_Store`). В `test_main_generates_site` — проверка, что в собранный `sw.js` попадает контентный хеш и **не** попадает дата.

### Заметки

- `Path.rglob` использовать не вышло: он делегирует в `Path.glob`, а тот замокан в тестах сборки — взял `os.walk`.
- **В браузере руками не проверял** — только логика, тесты, сборка и синтаксис.