### PR TITLE
Ограничить кеш Service Worker изображениями и иконками

### DIFF
--- a/tests/service_worker_harness.js
+++ b/tests/service_worker_harness.js
@@ -1,0 +1,148 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+const ORIGIN = 'https://onevents.ru';
+const STATIC_CACHE = 'onevents-static-test';
+const PAGE_CACHE = 'onevents-page';
+const listeners = {};
+const deletedCaches = [];
+const fetchCalls = [];
+
+function response(name) {
+  return {
+    name: name,
+    ok: true,
+    clone: function () { return this; }
+  };
+}
+
+function request(path, mode) {
+  return {
+    url: path.startsWith('http') ? path : ORIGIN + path,
+    method: 'GET',
+    mode: mode || 'cors'
+  };
+}
+
+function makeCache(initialRequests) {
+  return {
+    addedAssets: [],
+    deleted: [],
+    matches: [],
+    puts: [],
+    responses: new Map(),
+    addAll: function (assets) {
+      this.addedAssets = assets;
+      return Promise.resolve();
+    },
+    keys: function () { return Promise.resolve(initialRequests || []); },
+    match: function (cachedRequest) {
+      this.matches.push(cachedRequest.url);
+      return Promise.resolve(this.responses.get(cachedRequest.url));
+    },
+    put: function (cachedRequest, cachedResponse) {
+      this.puts.push([cachedRequest.url, cachedResponse.name]);
+      return Promise.resolve();
+    },
+    delete: function (cachedRequest) {
+      this.deleted.push(cachedRequest.url);
+      return Promise.resolve(true);
+    }
+  };
+}
+
+const staticCache = makeCache([
+  request('/'),
+  request('/json/events.json'),
+  request('/img/events/logo.png')
+]);
+const pageCache = makeCache();
+
+global.self = {
+  location: {origin: ORIGIN},
+  clients: {claim: function () { return Promise.resolve(); }},
+  skipWaiting: function () {},
+  addEventListener: function (name, handler) { listeners[name] = handler; }
+};
+
+global.caches = {
+  open: function (name) {
+    return Promise.resolve(name === PAGE_CACHE ? pageCache : staticCache);
+  },
+  keys: function () {
+    return Promise.resolve([STATIC_CACHE, PAGE_CACHE, 'onevents-static-old', 'third-party-cache']);
+  },
+  delete: function (name) {
+    deletedCaches.push(name);
+    return Promise.resolve(true);
+  },
+  match: function () {
+    throw new Error('Static requests must be matched only in STATIC_CACHE');
+  }
+};
+
+global.fetch = function (networkRequest) {
+  fetchCalls.push(networkRequest.url);
+  if (networkRequest.url === ORIGIN + '/offline/') {
+    return Promise.reject(new Error('offline'));
+  }
+  return Promise.resolve(response('network'));
+};
+
+const source = fs.readFileSync('web/sw.js', 'utf8').replace('{{ cache_version }}', 'test');
+vm.runInThisContext(source, {filename: 'web/sw.js'});
+
+async function dispatchFetch(fetchRequest) {
+  let responsePromise;
+  listeners.fetch({
+    request: fetchRequest,
+    respondWith: function (promise) { responsePromise = Promise.resolve(promise); }
+  });
+  return responsePromise;
+}
+
+async function main() {
+  let installation;
+  listeners.install({waitUntil: function (promise) { installation = promise; }});
+  await installation;
+  assert.equal(staticCache.addedAssets.includes('/'), false);
+  assert.equal(staticCache.addedAssets.every(function (asset) { return asset.startsWith('/icons/'); }), true);
+
+  assert.equal(await dispatchFetch(request('/json/events.json')), undefined);
+  assert.equal(await dispatchFetch(request('/rss/rss.xml')), undefined);
+  assert.equal(await dispatchFetch(request('/calendar/all.ics')), undefined);
+  assert.equal(await dispatchFetch(request('https://example.com/img/logo.png')), undefined);
+  assert.deepEqual(fetchCalls, []);
+
+  staticCache.responses.set(ORIGIN + '/icons/favicon.svg', response('cached-icon'));
+  const cachedIconResult = await dispatchFetch(request('/icons/favicon.svg'));
+  assert.equal(cachedIconResult.name, 'cached-icon');
+  assert.deepEqual(fetchCalls, []);
+
+  const imageResult = await dispatchFetch(request('/img/events/logo.png'));
+  assert.equal(imageResult.name, 'network');
+  assert.deepEqual(staticCache.matches, [ORIGIN + '/icons/favicon.svg', ORIGIN + '/img/events/logo.png']);
+  assert.deepEqual(staticCache.puts, [[ORIGIN + '/img/events/logo.png', 'network']]);
+
+  const navigationResult = await dispatchFetch(request('/', 'navigate'));
+  assert.equal(navigationResult.name, 'network');
+  assert.deepEqual(pageCache.matches, []);
+  assert.deepEqual(pageCache.puts, [[ORIGIN + '/', 'network']]);
+
+  pageCache.responses.set(ORIGIN + '/offline/', response('cached-page'));
+  const offlineResult = await dispatchFetch(request('/offline/', 'navigate'));
+  assert.equal(offlineResult.name, 'cached-page');
+  assert.equal(pageCache.matches.includes(ORIGIN + '/offline/'), true);
+
+  let activation;
+  listeners.activate({waitUntil: function (promise) { activation = promise; }});
+  await activation;
+  assert.deepEqual(deletedCaches, ['onevents-static-old']);
+  assert.deepEqual(staticCache.deleted, [ORIGIN + '/', ORIGIN + '/json/events.json']);
+}
+
+main().catch(function (error) {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -1,0 +1,5 @@
+import subprocess
+
+
+def test_service_worker_cache_contract():
+    subprocess.run(['node', 'tests/service_worker_harness.js'], check=True)

--- a/web/sw.js
+++ b/web/sw.js
@@ -11,7 +11,6 @@ const PAGE_CACHE = 'onevents-page';
 const NETWORK_TIMEOUT_MS = 3000;
 
 var STATIC_ASSETS = [
-  '/',
   '/icons/site.webmanifest',
   '/icons/favicon-96x96.png',
   '/icons/favicon.svg',
@@ -20,6 +19,27 @@ var STATIC_ASSETS = [
   '/icons/web-app-manifest-192x192.png',
   '/icons/web-app-manifest-512x512.png'
 ];
+
+function isCacheableStaticAsset(url) {
+  return url.pathname.startsWith('/img/') || url.pathname.startsWith('/icons/');
+}
+
+// Удаляем из текущего кеша страницы и экспорты, сохранённые прежней версией worker.
+function pruneStaticCache() {
+  return caches.open(STATIC_CACHE).then(function (cache) {
+    return cache.keys().then(function (requests) {
+      return Promise.all(
+        requests
+          .filter(function (request) {
+            return !isCacheableStaticAsset(new URL(request.url));
+          })
+          .map(function (request) {
+            return cache.delete(request);
+          })
+      );
+    });
+  });
+}
 
 self.addEventListener('install', function (event) {
   event.waitUntil(
@@ -32,17 +52,20 @@ self.addEventListener('install', function (event) {
 
 self.addEventListener('activate', function (event) {
   event.waitUntil(
-    caches.keys().then(function (keys) {
-      return Promise.all(
-        keys
-          .filter(function (key) {
-            return key !== STATIC_CACHE && key !== PAGE_CACHE;
-          })
-          .map(function (key) {
-            return caches.delete(key);
-          })
-      );
-    })
+    Promise.all([
+      pruneStaticCache(),
+      caches.keys().then(function (keys) {
+        return Promise.all(
+          keys
+            .filter(function (key) {
+              return key.startsWith('onevents-') && key !== STATIC_CACHE && key !== PAGE_CACHE;
+            })
+            .map(function (key) {
+              return caches.delete(key);
+            })
+        );
+      })
+    ])
   );
   self.clients.claim();
 });
@@ -100,16 +123,21 @@ self.addEventListener('fetch', function (event) {
     return;
   }
 
+  if (!isCacheableStaticAsset(url)) {
+    // JSON, RSS, ICS и прочие изменяемые ресурсы браузер получает напрямую из сети.
+    return;
+  }
+
   event.respondWith(
-    caches.match(event.request).then(function (cached) {
-      return cached || fetch(event.request).then(function (response) {
-        if (response.ok) {
-          var clone = response.clone();
-          caches.open(STATIC_CACHE).then(function (cache) {
+    caches.open(STATIC_CACHE).then(function (cache) {
+      return cache.match(event.request).then(function (cached) {
+        return cached || fetch(event.request).then(function (response) {
+          if (response.ok) {
+            var clone = response.clone();
             cache.put(event.request, clone);
-          });
-        }
-        return response;
+          }
+          return response;
+        });
       });
     })
   );


### PR DESCRIPTION
## Зачем

После перехода навигации на network-first Service Worker всё ещё применял cache-first ко всем остальным GET-запросам своего origin. В этот кеш могли попасть JSON-экспорты, RSS, ICS и другие изменяемые ресурсы. Такая запись возвращалась бы из Cache Storage без проверки сети до смены версии кеша изображений.

Кроме того, обработчик activate удалял все кеши origin, кроме двух текущих, включая потенциальные кеши других компонентов сайта.

## Новая стратегия

Service Worker теперь разделяет ресурсы по назначению:

- навигация и HTML продолжают использовать существующий network-first с таймаутом 3 секунды и офлайн-копией;
- только пути `/img/` и `/icons/` используют cache-first;
- JSON, RSS, ICS и прочие ненавигационные ресурсы не перехватываются worker и загружаются браузером напрямую из сети;
- cross-origin запросы, включая внешние пути с `/img/`, не перехватываются;
- изображения читаются строго из текущего `STATIC_CACHE`, а не через глобальный поиск по всем кешам origin.

## Миграция существующих пользователей

Имя статического кеша зависит от содержимого изображений и может не измениться при обновлении одного только `sw.js`. Поэтому новый worker при активации очищает из текущего static cache записи, которые были созданы старой версией и больше не относятся к `/img/` или `/icons/`.

Это удаляет:

- ранее предзагруженную `/`;
- случайно сохранённые JSON/RSS/ICS;
- другие устаревшие ненавигационные ответы.

Изображения и иконки остаются на месте, поэтому пользователям не потребуется заново загружать всю статику.

Корневая страница удалена из install-precache: она всё равно обслуживается отдельным `PAGE_CACHE` через navigation network-first.

## Безопасная очистка кешей

При activate удаляются только устаревшие кеши с префиксом `onevents-`. Текущий static cache, `onevents-page` и кеши с чужими именами сохраняются.

## Поведенческие тесты

Добавлен небольшой Node harness без сторонних npm-зависимостей. Pytest запускает настоящий шаблон `web/sw.js` в изолированном VM-контексте с имитацией Service Worker API.

Проверяются реальные ветки install/fetch/activate:

- install-precache не содержит `/` и состоит из `/icons/`;
- JSON, RSS и ICS обходят Service Worker;
- cross-origin запросы обходят Service Worker;
- cache hit для иконки возвращается без сети;
- cache miss для изображения загружает сеть и сохраняет ответ в STATIC_CACHE;
- успешная навигация возвращает сеть и обновляет PAGE_CACHE;
- при отказе сети навигация возвращает сохранённую страницу;
- activate удаляет старые non-static записи текущего static cache;
- activate удаляет старый кеш `onevents-*`, сохраняя текущие и чужой кеш.

## Проверки

- `pytest -q` — 137 passed;
- `ruff check .` — без ошибок;
- `ruff format --check tests/test_service_worker.py` — форматирование корректно;
- `node tests/service_worker_harness.js` — контракт выполнен;
- `node --check web/sw.js` — синтаксис шаблона корректен;
- `python3 create_web.py` — сайт собран;
- `node --check site/sw.js` — синтаксис итогового worker корректен;
- `git diff --check` — без ошибок пробелов.

PR основан напрямую на `main` и не включает изменения из PR #94.